### PR TITLE
fix #28

### DIFF
--- a/modules/shell.lua
+++ b/modules/shell.lua
@@ -45,8 +45,8 @@ return {
     },
     {
       name = "mbs.shell.require_path",
-      description = "The path from that require will use by default. Set to false to use the CraftOS default.",
-      default = false,
+      description = "The path from that require will use by default. Set to nil to use the CraftOS default.",
+      default = nil,
     },
     {
       name = "mbs.shell.strict_globals",


### PR DESCRIPTION
fixes #28 without reverting

I could change the shell to use the setting as a prepend to the defaults, which I think might be a better way of doing require replacements since the original (before I broke it) only allowed replacing some stuff, with turtle and command stuff still being tacked on if it was appropriate